### PR TITLE
Add lore loader and reasoning trace utilities

### DIFF
--- a/connectors/lore_loader.py
+++ b/connectors/lore_loader.py
@@ -1,0 +1,50 @@
+"""Simple lore data loader.
+
+This module demonstrates how to load external lore data from a JSON
+file. The loader returns a dictionary representing the lore content.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_lore(path: str | Path) -> Dict[str, Any]:
+    """Load lore data from ``path``.
+
+    Parameters
+    ----------
+    path:
+        Path to a JSON file containing lore data.
+
+    Returns
+    -------
+    dict
+        Parsed lore information that can be consumed by other parts of
+        the system.
+    """
+    path = Path(path)
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return data
+
+
+class LoreLoader:
+    """Example loader class for managing lore files."""
+
+    def __init__(self, lore_path: str | Path) -> None:
+        self.lore_path = Path(lore_path)
+
+    def load(self) -> Dict[str, Any]:
+        """Load and return lore data.
+
+        Example
+        -------
+        >>> loader = LoreLoader("arcanea_lore.json")
+        >>> lore = loader.load()
+        >>> print(lore["world"])
+        """
+        return load_lore(self.lore_path)
+

--- a/core/reasoning_trace.py
+++ b/core/reasoning_trace.py
@@ -1,0 +1,64 @@
+"""Reasoning trace builder.
+
+Provides helper functions to assemble and represent reasoning traces.
+A reasoning trace records the intermediate steps an agent takes to
+arrive at a conclusion.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List
+
+
+@dataclass
+class TraceStep:
+    """A single step in a reasoning trace."""
+
+    message: str
+    timestamp: datetime = field(default_factory=datetime.utcnow)
+
+
+@dataclass
+class ReasoningTrace:
+    """Collection of ``TraceStep`` objects."""
+
+    steps: List[TraceStep] = field(default_factory=list)
+
+    def add_step(self, message: str) -> None:
+        """Append a reasoning step to the trace."""
+        self.steps.append(TraceStep(message=message))
+
+    def to_dict(self) -> List[dict]:
+        """Return the trace as a list of serializable dictionaries."""
+        return [
+            {"message": step.message, "timestamp": step.timestamp.isoformat()}
+            for step in self.steps
+        ]
+
+
+class TraceBuilder:
+    """Helper for building reasoning traces programmatically."""
+
+    def __init__(self) -> None:
+        self.trace = ReasoningTrace()
+
+    def record(self, message: str) -> None:
+        """Record a reasoning message."""
+        self.trace.add_step(message)
+
+    def build(self) -> ReasoningTrace:
+        """Return the constructed reasoning trace.
+
+        Example
+        -------
+        >>> tb = TraceBuilder()
+        >>> tb.record("Analyze lore entry")
+        >>> tb.record("Synthesize response")
+        >>> trace = tb.build()
+        >>> print(trace.to_dict())
+        """
+        return self.trace
+
+


### PR DESCRIPTION
## Summary
- add example `LoreLoader` to demonstrate loading external lore data
- add simple reasoning trace builder utilities

## Testing
- `python -m py_compile connectors/lore_loader.py core/reasoning_trace.py`

------
https://chatgpt.com/codex/tasks/task_e_683dbfe4a330832084a1b191ff9f60c1